### PR TITLE
removed helpers and handlebars import

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ Package.describe({
 });
 
 Package.on_use(function(api) {
-  api.use(['handlebars', 'coffeescript', 'less', 'templating', 'underscore'], 'client');
+  api.use(['coffeescript', 'less', 'templating', 'underscore'], 'client');
 
 
   api.imply('spiderable', ['client', 'server']);

--- a/shareit.coffee
+++ b/shareit.coffee
@@ -1,10 +1,3 @@
-if Package.ui
-  Package.ui.Handlebars.registerHelper "shareit", ->
-    new Handlebars.SafeString(Template.shareit(this))
-else
-  Handlebars.registerHelper "shareit", ->
-    new Handlebars.SafeString(Template.shareit(this))
-
 Meteor.startup ->
 
   # Twitter


### PR DESCRIPTION
we can just use the inclusion helper and avoid importing handlebars and/or ui packages and just render it like so:
{{> shareit}}

should work for blaze and pre-blaze
