### PR TITLE
Fixing bug where if there was no data context social sharing would break

### DIFF
--- a/client/views/facebook/facebook.coffee
+++ b/client/views/facebook/facebook.coffee
@@ -1,5 +1,5 @@
 Template.shareit_fb.rendered = ->
-  return unless @data
+  data = @data || {}
 
   $('meta[property^="og:"]').remove()
 
@@ -7,19 +7,19 @@ Template.shareit_fb.rendered = ->
   # OpenGraph tags
   #
 
-  description = @data.excerpt || @data.description || @data.summary
+  description = data.excerpt || data.description || data.summary
 
   $('<meta>', { property: 'og:type', content: 'article' }).appendTo 'head'
   $('<meta>', { property: 'og:site_name', content: location.hostname }).appendTo 'head'
   $('<meta>', { property: 'og:url', content: location.origin + location.pathname }).appendTo 'head'
-  $('<meta>', { property: 'og:title', content: "#{@data.title}" }).appendTo 'head'
+  $('<meta>', { property: 'og:title', content: "#{data.title}" }).appendTo 'head'
   $('<meta>', { property: 'og:description', content: description }).appendTo 'head'
 
-  if @data.thumbnail
-    if typeof @data.thumbnail == "function"
-      img = @data.thumbnail()
+  if data.thumbnail
+    if typeof data.thumbnail == "function"
+      img = data.thumbnail()
     else
-      img = @data.thumbnail
+      img = data.thumbnail
     if img
       if not /^http(s?):\/\/+/.test(img)
         img = location.origin + img
@@ -30,11 +30,11 @@ Template.shareit_fb.rendered = ->
   # Facebook share button
   #
 
-  preferred_url = @data.url || location.origin + location.pathname
+  preferred_url = data.url || location.origin + location.pathname
   url = encodeURIComponent preferred_url
 
   base = "https://www.facebook.com/sharer/sharer.php"
-  title = encodeURIComponent @data.title
+  title = encodeURIComponent data.title
   summary = encodeURIComponent description
   href = base + "?s=100&p[url]=" + url + "&p[title]=" + title + "&p[summary]=" + summary
 

--- a/client/views/google/google.coffee
+++ b/client/views/google/google.coffee
@@ -1,11 +1,10 @@
 Template.shareit_google.rendered = () ->
-  return unless @data
-
+  data = @data || {}
   #
   # Google share button
   #
 
-  preferred_url = @data.url || location.origin + location.pathname
+  preferred_url = data.url || location.origin + location.pathname
   href = "https://plus.google.com/share?url=#{preferred_url}"
   @$(".google-share").attr "href", href
 

--- a/client/views/twitter/twitter.coffee
+++ b/client/views/twitter/twitter.coffee
@@ -1,12 +1,12 @@
 Template.shareit_twitter.rendered = ->
-  return unless @data
+  data = @data || {}
   $('meta[property^="twitter:"]').remove()
 
-  if @data.thumbnail
-    if typeof @data.thumbnail == "function"
-      img = @data.thumbnail()
+  if data.thumbnail
+    if typeof data.thumbnail == "function"
+      img = data.thumbnail()
     else
-      img = @data.thumbnail
+      img = data.thumbnail
     if img
       if not /^http(s?):\/\/+/.test(img)
         img = location.origin + img
@@ -19,15 +19,15 @@ Template.shareit_twitter.rendered = ->
   # What should go here?
   #$('<meta>', { property: 'twitter:site', content: '' }).appendTo 'head'
 
-  if @data.author
-    author = @data.author() if typeof(@data.author) is 'function'
-    author ||= @data.author
+  if data.author
+    author = data.author() if typeof(data.author) is 'function'
+    author ||= data.author
   if author and author.profile and author.profile.twitter
     $('<meta>', { property: 'twitter:creator', content: author.profile.twitter }).appendTo 'head'
 
-  description = @data.excerpt || @data.description || @data.summary
+  description = data.excerpt || data.description || data.summary
   $('<meta>', { property: 'twitter:url', content: location.origin + location.pathname }).appendTo 'head'
-  $('<meta>', { property: 'twitter:title', content: "#{@data.title}" }).appendTo 'head'
+  $('<meta>', { property: 'twitter:title', content: "#{data.title}" }).appendTo 'head'
   $('<meta>', { property: 'twitter:description', content: description }).appendTo 'head'
   $('<meta>', { property: 'twitter:image:src', content: img }).appendTo 'head'
 
@@ -35,12 +35,14 @@ Template.shareit_twitter.rendered = ->
   # Twitter share button
   #
 
-  preferred_url = @data.url || location.origin + location.pathname
+  preferred_url = data.url || location.origin + location.pathname
   url = encodeURIComponent preferred_url
 
   base = "https://twitter.com/intent/tweet"
-  text = encodeURIComponent @data.title
-  href = base + "?url=" + url + "&text=" + text
+  href = base + "?url=" + url
+
+  if data.title
+    href += "&text=" + encodeURIComponent data.title
 
   if author and author.profile and author.profile.twitter
     href += "&via=" + author.profile.twitter


### PR DESCRIPTION
If you use {{> shareit}} on a normal page (not blog post) that doesn't have a @data context it breaks the sharing functions (because of the premature return)
