### PR TITLE
added missing , in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Somewhere in your client (not server) code you can configure ShareIt.  This is c
         'twitter': {},
         'googleplus': {},
         'pinterest': {}
-    }
+    },
     classes: "large btn", // string (default: 'large btn')
                           // The classes that will be placed on the sharing buttons, bootstrap by default.
     iconOnly: false,      // boolean (default: false)


### PR DESCRIPTION
found it through js2.coffee, which refused to parse it without it, gotta love coffee :)