### PR TITLE
Add the possibility to use or not a social network

### DIFF
--- a/client/views/social.js
+++ b/client/views/social.js
@@ -5,7 +5,7 @@ Template.shareit.helpers({
     ref = ShareIt.settings.siteOrder;
     for (i = 0, len = ref.length; i < len; i++) {
       site = ref[i];
-      if (ShareIt.settings.sites[site] != null) {
+      if (ShareIt.settings.sites[site] != null && ShareIt.settings.sites[site].use) {
         templates.push('shareit_' + site);
       }
     }

--- a/shareit.js
+++ b/shareit.js
@@ -1,4 +1,3 @@
-
 ShareIt = {
   settings: {
     autoInit: true,
@@ -7,19 +6,24 @@ ShareIt = {
       'facebook': {
         'appId': null,
         'version': 'v2.1',
-        'description': ''
+        'description': '',
+        'use': true
       },
       'twitter': {
-        'description': ''
+        'description': '',
+        'use': true
       },
       'googleplus': {
-        'description': ''
+        'description': '',
+        'use': true
       },
       'pinterest': {
-        'description': ''
+        'description': '',
+        'use': true
       },
       'instagram': {
-        'description': ''
+        'description': '',
+        'use': true
       }
     },
     siteOrder: ['facebook', 'twitter', 'pinterest', 'googleplus', 'instagram'],


### PR DESCRIPTION
Offer the possibility to put a use: true or use: false in the description section for each social network to enable or disable it. By default they are all set to true.

```
ShareIt.configure({
    sites: {                // nested object for extra configurations
        'facebook': {
            'appId': null   // use sharer.php when it's null, otherwise use share dialog
        },
        'twitter': {},
        'googleplus': {
            'use': false
        },
        'pinterest': {
            'use': false
        },
        'instagram': {
            'use': false
        }
    },
    classes: "btn", // string (default: 'large btn')
                          // The classes that will be placed on the sharing buttons, bootstrap by default.
    iconOnly: true,      // boolean (default: false)
                          // Don't put text on the sharing buttons
    applyColors: true,     // boolean (default: true)
    // apply classes to inherit each social networks background color
    faSize: '',            // font awesome size
    faClass: ''       // font awesome classes like square
});
```
